### PR TITLE
Fix L2/R2 key codes and re-enable analog joystick in RG350

### DIFF
--- a/source/opendingux/draw.c
+++ b/source/opendingux/draw.c
@@ -61,7 +61,7 @@ static struct timespec LastProgressUpdate;
 
 void init_video()
 {
-	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO /*| SDL_INIT_JOYSTICK*/) < 0)
+	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK) < 0)
 	{
 		printf("Failed to initialize SDL !!\n");
 		return;   // for debug

--- a/source/opendingux/od-input.c
+++ b/source/opendingux/od-input.c
@@ -32,8 +32,8 @@ uint32_t AnalogAction = 0;
 
 uint_fast8_t FastForwardFrameskipControl = 0;
 
-//static SDL_Joystick* Joystick;
-
+// left analog joystick
+static SDL_Joystick* Joystick;
 static bool JoystickInitialised = false;
 
 // Mandatory remapping for OpenmDingux keys. Each OpenmDingux key maps to a
@@ -360,33 +360,27 @@ enum OpenDingux_Buttons GetPressedOpenDinguxButtons()
 
 static void EnsureJoystick()
 {
-	// if (!JoystickInitialised)
-	// {
-		// JoystickInitialised = true;
-		// Joystick = SDL_JoystickOpen(0);
-		// if (Joystick == NULL)
-		// {
-			// ReGBA_Trace("I: Joystick #0 could not be opened");
-		// }
-	// }
+	if (!JoystickInitialised)
+	{
+		JoystickInitialised = true;
+		Joystick = SDL_JoystickOpen(0);
+		if (Joystick == NULL)
+		{
+			ReGBA_Trace("I: Joystick #0 could not be opened");
+		}
+	}
 }
 
 int16_t GetHorizontalAxisValue()
 {
-	// EnsureJoystick();
-	// if (Joystick != NULL)
-		// return SDL_JoystickGetAxis(Joystick, 0);
-	// else
-		return 0;
+	EnsureJoystick();
+	return (Joystick != NULL) ? SDL_JoystickGetAxis(Joystick, 0) : 0;
 }
 
 int16_t GetVerticalAxisValue()
 {
-	// EnsureJoystick();
-	// if (Joystick != NULL)
-		// return SDL_JoystickGetAxis(Joystick, 1);
-	// else
-		return 0;
+	EnsureJoystick();
+	return (Joystick != NULL) ? SDL_JoystickGetAxis(Joystick, 1) : 0;
 }
 
 enum GUI_ActionRepeatState

--- a/source/opendingux/od-input.c
+++ b/source/opendingux/od-input.c
@@ -60,8 +60,8 @@ uint32_t OpenDinguxKeys[OPENDINGUX_BUTTON_COUNT] = {
 	SDLK_RSHIFT,     // PLAYGO: L2
 	SDLK_RALT,       // PLAYGO: R2
 #elif defined RG350
-	SDLK_BACKSPACE,  // RG350: L2
-	SDLK_PAGEUP,     // RG350: R2
+	SDLK_PAGEUP,     // RG350: L2
+	SDLK_PAGEDOWN,   // RG350: R2
 #else
 	0,
 	0,


### PR DESCRIPTION
The analog joystick had been broken in the commit 186710fc880d5ea2b35e90c9ec38a5ca6164ae20.
This patch re-enable it and also fix the key codes for the L2 and R2 in the RG350.